### PR TITLE
Build GDB without Guile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ binutils-build: $(binutils_src)
 		--target=riscv32-unknown-elf \
 		--prefix=$(binutils_dest) \
 		--disable-werror \
-		--enable-debug
+		--enable-debug \
+		--without-guile
 	$(MAKE) -C $(binutils_build)
 	$(MAKE) -C $(binutils_build) install
 $(binutils_dest)/bin/riscv32-unknown-elf-gdb: binutils-build


### PR DESCRIPTION
GDB requires Guile 2.0 and breaks with newer versions.
Thus disable Guile features until GDB caught up.

Closes: #6

See-Also: sifive/freedom-e-sdk#83

Signed-Off-By: Dennis Schridde <devurandom@gmx.net>