### PR TITLE
Support setting LLVM build parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ root_dir           := $(CURDIR)
 build_dir          := $(root_dir)/build
 sysroot_dir        := $(root_dir)/toolchain
 target             := riscv32-unknown-elf
+nproc              :=
 
 
 all: toolchain
@@ -36,7 +37,7 @@ llvm-configure: $(llvm_src)
 $(llvm_build): llvm-configure
 
 llvm-build: $(llvm_build)
-	cmake --build $(llvm_build)
+	cmake --build $(llvm_build) -- $(if $(nproc),-j$(nproc))
 $(llvm_build)/bin/llc: llvm-build
 
 llvm-install: $(llvm_build)/bin/llc


### PR DESCRIPTION
This adds an "nproc" variable to the Makefile, which allows the user to
 configure the build parallelism (currently only supported for the LLVM build).
 I.e. this variable is passed on to the build tool via `-j$(nproc)`, if set.

The variable is not set by default, which means the build behaves just like
 before, using the default parallelism of the build tool (e.g. nproc + 2 for
 Ninja).  It can be set on the command line as e.g. `make nproc=2` (to force
 it to a fixed number) or `make nproc=$(nproc)` (to set it to the number of
 available processors).

On "memory constrained" systems with e.g. 4 CPUs, but "only" 8 GiB of RAM, this
 is necessary in order to prevent the LLVM build from consuming excessive
 amounts of memory and thus locking up the entire system.

Signed-Off-By: Dennis Schridde <devurandom@gmx.net>