### PR TITLE
Use ccache if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ root_dir           := $(CURDIR)
 build_dir          := $(root_dir)/build
 sysroot_dir        := $(root_dir)/toolchain
 target             := riscv32-unknown-elf
+ccache             := $(shell which ccache)
 
 
 all: toolchain
@@ -22,6 +23,8 @@ llvm-configure: $(llvm_src)
 	mkdir -p $(llvm_build)
 	cd $(llvm_build); \
 	cmake $(llvm_src) -G "Ninja" \
+		$(if $(ccache),-DCMAKE_C_COMPILER_LAUNCHER="$(ccache)") \
+		$(if $(ccache),-DCMAKE_CXX_COMPILER_LAUNCHER="$(ccache)") \
 										-DCMAKE_INSTALL_PREFIX=$(llvm_dest) \
 										-DCMAKE_BUILD_TYPE="Debug" \
 										-DLLVM_USE_SPLIT_DWARF=True \
@@ -76,7 +79,8 @@ rust-build: $(sysroot_dir)/bin/cc
               --infodir=$(rust_dest)/share/info \
               --default-linker=gcc \
               --llvm-root=$(llvm_dest) \
-              --enable-llvm-link-shared
+              --enable-llvm-link-shared \
+		--enable-ccache
 	cd $(rust_src) && make
 	cd $(rust_src) && make install
 $(rust_dest)/bin/rustc: rust-build
@@ -106,7 +110,9 @@ openocd-build: $(openocd_src)
     --prefix=$(openocd_dest) \
     --disable-werror \
 		--enable-remote-bitbang \
-    --enable-ftdi
+    --enable-ftdi \
+		$(if $(ccache),CC="$(ccache) $(CC)") \
+		$(if $(ccache),CXX="$(ccache) $(CXX)")
 	$(MAKE) -C $(openocd_build)
 	$(MAKE) -C $(openocd_build) install
 $(openocd_dest)/bin/openocd: openocd-build
@@ -126,7 +132,9 @@ binutils-build: $(binutils_src)
 		--disable-werror \
 		--enable-debug \
 		--without-guile \
-		--enable-python
+		--enable-python \
+		$(if $(ccache),CC="$(ccache) $(CC)") \
+		$(if $(ccache),CXX="$(ccache) $(CXX)")
 	$(MAKE) -C $(binutils_build)
 	$(MAKE) -C $(binutils_build) install
 $(binutils_dest)/bin/$(target)-gdb: binutils-build


### PR DESCRIPTION
In order to speed up the build, ccache is now being used by default, if
 available.  This can be overridden on the commandline by specifying
 `make ccache=`, i.e. providing an empty value for the "ccache" variable.
 In the same manner a custom ccache executable can be provided, in case it is
 not available in `$PATH`: `make ccache=/path/to/ccache`.

This requires at least CMake 3.4 to work and will generate a non-fatal warning
 in older versions.

Signed-Off-By: Dennis Schridde <devurandom@gmx.net>