### PR TITLE
Sanitize the "clean" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ccache             := $(shell which ccache)
 all: toolchain
 
 clean:
-	git clean -qdfx
+	$(RM) -r build toolchain
 
 toolchain: llvm openocd binutils rust xargo
 	@echo All Tools Installed


### PR DESCRIPTION
`git clean -qfdx` is useful, but also unexpected for a "clean" target.  Replace
 the command with a more sane `$(RM) -r build toolchain`.

Fixes: 00002c75c357748977dd973e7b7e5bfefaa96ebf

Signed-Off-By: Dennis Schridde <devurandom@gmx.net>