### PR TITLE
Rename "nproc" variable to "jobs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ root_dir           := $(CURDIR)
 build_dir          := $(root_dir)/build
 sysroot_dir        := $(root_dir)/toolchain
 target             := riscv32-unknown-elf
-nproc              :=
-makeflags          := $(if $(nproc),-j$(nproc))
+jobs               :=
+makeflags          := $(if $(jobs),-j$(jobs))
 ccache             := $(shell which ccache)
 
 


### PR DESCRIPTION
Rust names it "jobs", too.

Fixes: ad61bf8325774d4858ffb3a8127629b174d27db8
Fixes: df53819082c8c758661fabe4864afa45fce662b6

Signed-Off-By: Dennis Schridde <devurandom@gmx.net>